### PR TITLE
Remove superfluous rbenv init

### DIFF
--- a/providers/execute.rb
+++ b/providers/execute.rb
@@ -18,10 +18,6 @@ def load_current_resource
 end
 
 action :run do
-  execute "eval \"$(rbenv init -)\"" do
-    environment new_resource.environment
-  end
-
   execute new_resource.name do
     command     new_resource.command
     creates     new_resource.creates


### PR DESCRIPTION
`eval $(rbenv init -)` is only intended for interactive shell use. The
non-interactive parts are not needed here.

1. setting PATH and RBENV_SHELL (which is already set in environment)
2. Run rehash (already run in install_package)