### PR TITLE
Use --no-document arg to gem install

### DIFF
--- a/libraries/provider_rbenv_rubygems.rb
+++ b/libraries/provider_rbenv_rubygems.rb
@@ -85,7 +85,7 @@ class Chef
           version_option = (version.nil? || version.empty?) ? "" : " -v \"#{version}\""
 
           shell_out!(
-            "#{gem_binary_path} install #{name} -q --no-rdoc --no-ri #{version_option} #{src}#{opts}",
+            "#{gem_binary_path} install #{name} -q --no-document #{version_option} #{src}#{opts}",
             :user => node[:rbenv][:user],
             :group => node[:rbenv][:group],
             :env => {

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       "Riot Games"
 maintainer_email "jamie@vialstudios.com"
 license          "Apache 2.0"
 description      "Installs and configures rbenv"
-version          "1.7.1"
+version          "1.7.2"
 
 recipe "rbenv", "Installs and configures rbenv"
 recipe "rbenv::ruby_build", "Installs and configures ruby_build"


### PR DESCRIPTION
Fix for ruby 2.7: `--no-document` argument replaces `--no-rdoc` and `--no-ri`